### PR TITLE
Fix multisign info

### DIFF
--- a/src/components/tables/TableView.vue
+++ b/src/components/tables/TableView.vue
@@ -49,7 +49,7 @@ export default {
 				'publicKeyHeight',
 				'importanceHeight',
 				'multisigAddresses_',
-				'cosignatories_',
+				'cosignatoryAddresses_',
 
 				'signer',
 				'recipient',
@@ -74,8 +74,8 @@ export default {
 				'restrictionAddressDeletions',
 				'restrictionMosaicAdditions',
 				'restrictionMosaicDeletions',
-				'addressAdditions',
-				'addressDeletions',
+				'addressAdditions_',
+				'addressDeletions_',
 				'linkedAccountAddress'
 			],
 			disableClickValues: [...Object.values(Constants.Message)],
@@ -89,7 +89,7 @@ export default {
 			],
 			allowArrayToView: [
 				'linkedNamespace',
-				'cosignatories',
+				'cosignatoryAddresses',
 				'multisigAddresses',
 				'restrictionAddressValues',
 				'restrictionMosaicValues',
@@ -154,7 +154,10 @@ export default {
                 key === 'owneraddress' ||
                 key === 'host' ||
                 key === 'friendlyName' ||
-                key === 'multisigAddresses_'
+                key === 'multisigAddresses_' ||
+				key === 'cosignatoryAddresses_' ||
+				key === 'addressAdditions_' ||
+				key === 'addressDeletions_'
 			);
 		},
 

--- a/src/config/i18n/en-us.json
+++ b/src/config/i18n/en-us.json
@@ -187,7 +187,7 @@
     "effectiveMosaicRentalFee": "Mosaic Rental Fee",
     "recipientAddress": "Recipient",
     "senderAddress": "Sender",
-    "cosignatories": "Cosignatories",
+    "cosignatoryAddresses": "Cosignatories",
     "multisigAddresses": "Multisig Accounts",
     "effectiveFee": "Fee",
     "linkedPublicKey": "linked Public Key",

--- a/src/config/i18n/ja.json
+++ b/src/config/i18n/ja.json
@@ -187,7 +187,7 @@
     "effectiveMosaicRentalFee": "モザイクレンタル手数料",
     "recipientAddress": "受信者",
     "senderAddress": "送信者",
-    "cosignatories": "連署者",
+    "cosignatoryAddresses": "連署者",
     "multisigAddresses": "マルチシグアカウント",
     "effectiveFee": "手数料",
     "linkedPublicKey": "リンク済み公開鍵",

--- a/src/config/key-redirects.json
+++ b/src/config/key-redirects.json
@@ -13,8 +13,10 @@
     "restrictionAddressValues": "account",
     "restrictionAddressAdditions": "account",
     "restrictionAddressDeletions": "account",
-    "cosignatories": "account",
+    "cosignatoryAddresses_": "account",
     "multisigAddresses_": "account",
+    "addressAdditions_": "account",
+    "addressDeletions_": "account",
     "linkedAccountAddress": "account",
 
     "transactionHash": "transaction",

--- a/src/config/pages/account-detail.json
+++ b/src/config/pages/account-detail.json
@@ -40,8 +40,8 @@
 				"fields": [
 					"minApproval",
 					"minRemoval",
-					"cosignatories",
-					"multisigAccounts"
+					"cosignatoryAddresses",
+					"multisigAddresses"
 				]
 			},
 			{

--- a/src/infrastructure/MultisigService.js
+++ b/src/infrastructure/MultisigService.js
@@ -53,8 +53,10 @@ class MultisigService {
 
   	return {
   		...multisigAccountInfo,
-  		cosignatories: multisigAccountInfo?.cosignatoryAddresses?.map(cosigner => cosigner.address.plain()),
-  		multisigAddresses: multisigAccountInfo?.multisigAddresses?.map(cosigner => cosigner.address.plain())
+  		minApproval: multisigAccountInfo?.cosignatoryAddresses.length > 0 ? multisigAccountInfo.minApproval : null,
+  		minRemoval: multisigAccountInfo?.cosignatoryAddresses.length > 0 ? multisigAccountInfo.minRemoval : null,
+  		cosignatoryAddresses: multisigAccountInfo?.cosignatoryAddresses,
+  		multisigAddresses: multisigAccountInfo?.multisigAddresses
   	};
   }
 
@@ -65,8 +67,8 @@ class MultisigService {
    */
   static formatMultisigAccountInfo = multisigAccountInfo => ({
   	...multisigAccountInfo,
-  	cosignatories: multisigAccountInfo.cosignatoryAddresses.map(cosigner => cosigner.address.plain()),
-  	multisigAddresses: multisigAccountInfo.multisigAddresses.map(cosigner => cosigner.address.plain())
+  	cosignatoryAddresses: multisigAccountInfo.cosignatoryAddresses.map(address => address.plain()),
+  	multisigAddresses: multisigAccountInfo.multisigAddresses.map(address => address.plain())
   })
 }
 


### PR DESCRIPTION
### Bug fixes
- Multisign info display error.

### Update
- if account is under `Multisig`, It will show cosignatories, min approval and min removal info
- if account is under `cosignatories`, it will only show Multisig account info

Resolved: #559 