### PR TITLE
fixes display wrong expiration date and time

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -433,7 +433,7 @@ class helper {
   static isNativeNamespace = (namespaceName) => {
   	const values = Object.values(http.networkCurrency.namespace);
 
-  	return values.indexOf(namespaceName) !== -1;
+  	return values.indexOf(namespaceName.toUpperCase()) !== -1;
   }
 
   /**

--- a/src/infrastructure/LockService.js
+++ b/src/infrastructure/LockService.js
@@ -74,7 +74,7 @@ class LockService {
     static formatSecretLockInfo = (secretLockInfo) => ({
     	...secretLockInfo,
     	amount: helper.formatMosaicAmountWithDivisibility(secretLockInfo.amount, http.networkCurrency.divisibility),
-    	endHeight: secretLockInfo.endHeight.compact(),
+    	endHeight: Number(secretLockInfo.endHeight.toString()),
     	mosaicId: secretLockInfo.mosaicId.toHex(),
     	ownerAddress: secretLockInfo.ownerAddress.plain(),
     	recipient: secretLockInfo.recipientAddress.plain(),
@@ -89,7 +89,7 @@ class LockService {
     static formatHashLockInfo = (hashLockInfo) => ({
     	...hashLockInfo,
     	amount: helper.formatMosaicAmountWithDivisibility(hashLockInfo.amount, http.networkCurrency.divisibility),
-    	endHeight: hashLockInfo.endHeight.compact(),
+    	endHeight: Number(hashLockInfo.endHeight.toString()),
     	mosaicId: hashLockInfo.mosaicId.toHex(),
     	ownerAddress: hashLockInfo.ownerAddress.plain()
     })

--- a/src/infrastructure/MosaicService.js
+++ b/src/infrastructure/MosaicService.js
@@ -175,7 +175,7 @@ class MosaicService {
    	supply: mosaicInfo.supply.compact().toLocaleString('en-US'),
    	relativeAmount: helper.formatMosaicAmountWithDivisibility(mosaicInfo.supply, mosaicInfo.divisibility),
    	revision: mosaicInfo.revision,
-   	startHeight: mosaicInfo.startHeight.compact(),
+   	startHeight: Number(mosaicInfo.startHeight.toString()),
    	duration: mosaicInfo.duration.compact() > 0 ? mosaicInfo.duration.compact() : Constants.Message.UNLIMITED,
    	supplyMutable: mosaicInfo.flags.supplyMutable,
    	transferable: mosaicInfo.flags.transferable,

--- a/src/infrastructure/NamespaceService.js
+++ b/src/infrastructure/NamespaceService.js
@@ -157,10 +157,10 @@ class NamespaceService {
   		formattedNamespaceInfo.aliasMosaic = namespace.alias;
 
   	// End height disable click before expired.
-  	formattedNamespaceInfo.expiredInBlock = helper.isNativeNamespace(namespace.namespaceName.toUpperCase()) ? Constants.Message.INFINITY : expiredInBlock + ` ≈ ` + formattedNamespaceInfo.duration;
+  	formattedNamespaceInfo.expiredInBlock = helper.isNativeNamespace(namespace.namespaceName) ? Constants.Message.INFINITY : expiredInBlock + ` ≈ ` + formattedNamespaceInfo.duration;
 
   	if (!isExpired) {
-  		formattedNamespaceInfo.beforeEndHeight = helper.isNativeNamespace(namespace.namespaceName.toUpperCase()) ? Constants.Message.INFINITY : formattedNamespaceInfo.endHeight + ` ( ${http.networkConfig.NamespaceGraceDuration} blocks of grace period )`;
+  		formattedNamespaceInfo.beforeEndHeight = helper.isNativeNamespace(namespace.namespaceName) ? Constants.Message.INFINITY : formattedNamespaceInfo.endHeight + ` ( ${http.networkConfig.NamespaceGraceDuration} blocks of grace period )`;
   		delete formattedNamespaceInfo.endHeight;
   	}
 
@@ -201,14 +201,14 @@ class NamespaceService {
   	return {
   		...namespaceInfos,
   		data: namespaceInfos.data.map(namespace => {
-  			const { isExpired, expiredInSecond, expiredInBlock } = helper.calculateNamespaceExpiration(currentHeight, namespace.endHeight);
+			  const { isExpired, expiredInSecond, expiredInBlock } = helper.calculateNamespaceExpiration(currentHeight, namespace.endHeight);
 
   			return {
   				...namespace,
   				owneraddress: namespace.ownerAddress,
-  				expirationDuration: helper.convertTimeFromNowInSec(expiredInSecond) || Constants.Message.UNLIMITED,
+  				expirationDuration: helper.isNativeNamespace(namespace.namespaceName) ? Constants.Message.INFINITY : helper.convertTimeFromNowInSec(expiredInSecond),
   				isExpired: isExpired,
-  				approximateExpired: helper.convertSecondToDate(expiredInSecond),
+  				approximateExpired: helper.isNativeNamespace(namespace.namespaceName) ? Constants.Message.INFINITY : helper.convertSecondToDate(expiredInSecond),
   				expiredInBlock: expiredInBlock
   			};
   		})
@@ -301,10 +301,10 @@ class NamespaceService {
   	namespaceName: namespace.name,
   	namespaceId: namespace.id.toHex(),
   	registrationType: Constants.NamespaceRegistrationType[namespace.registrationType],
-  	startHeight: namespace.startHeight.compact(),
-  	endHeight: helper.isNativeNamespace(namespace.name.toUpperCase())
+  	startHeight: Number(namespace.startHeight.toString()),
+  	endHeight: helper.isNativeNamespace(namespace.name)
   		? Constants.Message.INFINITY
-  		: namespace.endHeight.compact(),
+  		: Number(namespace.endHeight.toString()),
   	active: namespace.active ? Constants.Message.ACTIVE : Constants.Message.INACTIVE,
   	...this.formatAlias(namespace.alias),
   	parentName: namespace.registrationType !== 0 ? namespace.name.split('.')[0].toUpperCase() : '',


### PR DESCRIPTION
### Bug fixes
- Resolved: #664 

### Update
- Change startHeight / endHeight `compact()` to `toString()` to prevent the error.
```
Compacted value is greater than 
Number.Max_Value.
```