### PR TITLE
display comfirmation date and block height in transaction list.

### DIFF
--- a/src/config/pages/account-detail.json
+++ b/src/config/pages/account-detail.json
@@ -113,14 +113,15 @@
 				"hideDependOnGetter": "account/info",
 				"onRowClickKey": "transactionHash",
 				"fields": [
-					"deadline",
+					"date",
+					"blockHeight",
 					"direction",
 					"transactionType",
 					"transactionHash",
 					"recipient"
 				],
 				"mobileFields": [
-					"deadline",
+					"date",
 					"direction",
 					"transactionType",
 					"transactionHash"


### PR DESCRIPTION
### Added
- display confirmation date and block height in the transaction list on Account detail pages.

Resolved: #765

![Screenshot 2021-01-24 at 12 36 46 AM](https://user-images.githubusercontent.com/5649156/105608033-875adf80-5ddc-11eb-9ed2-04b744dedb3f.png)
