### PR TITLE
Harvester redirect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 node_js:
   - "12"
   - "lts/*"
-  - "node"
+  # - "node" node-js v16 is not support node-sass yet https://github.com/sass/node-sass/issues/3077
 env:
   global:
     - DEV_BRANCH=dev
@@ -34,19 +34,19 @@ jobs:
     - stage: test
       name: docker test build
       script: /bin/bash travis/docker-functions.sh docker_build $VERSION
-      node_js: 10
+      node_js: 12
     - stage: publish
       name: docker publish alpha
       script: /bin/bash travis/docker-functions.sh docker_build $VERSION publish
       if: branch = env(DEV_BRANCH) AND type = push
-      node_js: 10
+      node_js: 12
     - stage: release
       name: docker publish release
       script: /bin/bash travis/docker-functions.sh docker_build $VERSION release
       if: branch = env(RELEASE_BRANCH) AND type = api AND commit_message = env(RELEASE_MESSAGE)
-      node_js: 10
+      node_js: 12
     - stage: post release
       name: tag and version upgrade
       script: /bin/bash travis/node-functions.sh node_post_release
       if: branch = env(RELEASE_BRANCH) AND type = api AND commit_message = env(RELEASE_MESSAGE)
-      node_js: 10
+      node_js: 12

--- a/src/components/fields/Harvester.vue
+++ b/src/components/fields/Harvester.vue
@@ -19,7 +19,7 @@
 <template>
 	<div class="harvester-container">
 		<span :title="title" >
-			<router-link :to="getItemHref('accounts', value.linked)">
+			<router-link :to="getItemHref('accounts', value.linkedAddress)">
 				<b class="link">{{ value.signer }}</b>
 			</router-link>
 		</span>
@@ -40,7 +40,7 @@ export default {
 			return this.getKeyName('remote') +
 			': ' + this.value.signer +
 			'\n' + this.getKeyName('main') +
-			': ' + this.value.linked;
+			': ' + this.value.linkedAddress;
 		}
 	}
 };

--- a/src/components/fields/Harvester.vue
+++ b/src/components/fields/Harvester.vue
@@ -1,0 +1,47 @@
+/*
+ *
+ * Copyright (c) 2019-present for NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License ");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+<template>
+	<div class="harvester-container">
+		<span :title="title" >
+			<router-link :to="getItemHref('accounts', value.linked)">
+				<b class="link">{{ value.signer }}</b>
+			</router-link>
+		</span>
+	</div>
+</template>
+
+<script>
+import TableView from '@/components/tables/TableView.vue';
+
+export default {
+	name: 'Harvester',
+	extends: TableView,
+	props: {
+		value: Object
+	},
+	computed: {
+		title() {
+			return this.getKeyName('remote') +
+			': ' + this.value.signer +
+			'\n' + this.getKeyName('main') +
+			': ' + this.value.linked;
+		}
+	}
+};
+</script>

--- a/src/components/tables/TableInfoView.vue
+++ b/src/components/tables/TableInfoView.vue
@@ -20,6 +20,7 @@
 						<Age v-else-if="isAge(itemKey)" :date="item" />
 						<DateField v-else-if="itemKey === 'timestamp'" :timestamp="item" />
 						<MessageField v-else-if="itemKey === 'message'" :value="item" />
+						<Harvester v-else-if="itemKey === 'harvester'" :value="item" />
 
 						<router-link
 							v-else-if="isKeyClickable(itemKey) && getItemHref(itemKey, item)"
@@ -43,6 +44,7 @@ import TransactionType from '@/components/fields/TransactionType.vue';
 import BlockHeightWithFinalizedStatusField from '@/components/fields/BlockHeightWithFinalizedStatusField.vue';
 import MessageField from '@/components/fields/MessageField.vue';
 import DateField from '@/components/fields/DateField.vue';
+import Harvester from '@/components/fields/Harvester.vue';
 
 export default {
 	extends: TableView,
@@ -53,7 +55,8 @@ export default {
 		TransactionType,
 		BlockHeightWithFinalizedStatusField,
 		MessageField,
-		DateField
+		DateField,
+		Harvester
 	},
 
 	props: {

--- a/src/components/tables/TableInfoView.vue
+++ b/src/components/tables/TableInfoView.vue
@@ -8,8 +8,7 @@
 					</td>
 					<td
 						class="'max-item-width table-cell break-all"
-						:title="getKeyName(itemKey) + ': ' + item"
-						@click="onItemClick(itemKey, item)"
+						:title="getKeyName(itemKey) + (typeof item !== 'string' ? '' : ': ' +  item)"
 					>
 						<ArrayField v-if="isArrayField(itemKey)" :itemKey="itemKey" :value="item" />
 						<MosaicsField v-else-if="itemKey === 'mosaics'" :value="item" />

--- a/src/components/tables/TableListView.vue
+++ b/src/components/tables/TableListView.vue
@@ -40,6 +40,7 @@
 							<ExtendGraphicValueField v-else-if="itemKey === 'extendGraphicValue'" :value="item" :transactionType="row['transactionType']"/>
 							<DateField v-else-if="itemKey === 'timestamp'" :timestamp="item" />
 							<SoftwareVersion v-else-if="itemKey === 'softwareVersion'" :value="item" />
+							<Harvester v-else-if="itemKey === 'harvester'" :value="item" />
 
 							<div v-else-if="isAggregateInnerTransaction(itemKey)">
 								<b-link v-b-modal="'tlv_r'+rowIndex">Show Detail</b-link>
@@ -109,6 +110,7 @@ import RewardPrograms from '@/components/fields/RewardPrograms';
 import ChainInfo from '@/components/fields/ChainInfo';
 import DateField from '@/components/fields/DateField.vue';
 import SoftwareVersion from '@/components/fields/SoftwareVersion.vue';
+import Harvester from '@/components/fields/Harvester.vue';
 
 export default {
 	extends: TableView,
@@ -127,7 +129,8 @@ export default {
 		ChainInfo,
 		Loading,
 		DateField,
-		SoftwareVersion
+		SoftwareVersion,
+		Harvester
 	},
 
 	props: {

--- a/src/components/tables/TableView.vue
+++ b/src/components/tables/TableView.vue
@@ -82,6 +82,10 @@ export default {
 				'linkedAccountAddress',
 				'ownerAddress',
 				'senderAddress',
+				'linkedAddress',
+				'nodeAddress',
+				'vrfAddress',
+				'voting_',
 
 				'namespaceArtifactId',
 				'mosaicArtifactId',

--- a/src/config/i18n/en-us.json
+++ b/src/config/i18n/en-us.json
@@ -392,5 +392,8 @@
     "restVersion": "REST Version",
     "softwareVersion": "Version",
     "remote": "Remote",
-    "main": "Main"
+    "main": "Main",
+    "linkedAddress": "Linked",
+    "nodeAddress": "Node",
+    "vrfAddress": "VRF"
 }

--- a/src/config/i18n/en-us.json
+++ b/src/config/i18n/en-us.json
@@ -390,5 +390,7 @@
     "timestamp": "Timestamp",
     "symbolTime": "Symbol Time",
     "restVersion": "REST Version",
-    "softwareVersion": "Version"
+    "softwareVersion": "Version",
+    "remote": "Remote",
+    "main": "Main"
 }

--- a/src/config/i18n/es.json
+++ b/src/config/i18n/es.json
@@ -386,5 +386,7 @@
     "timestamp": "Timestamp",
     "symbolTime": "Symbol Time",
     "restVersion": "Rest Version",
-    "softwareVersion": "Version"
+    "softwareVersion": "Version",
+    "remote": "Remote",
+    "main": "Main"
 }

--- a/src/config/i18n/es.json
+++ b/src/config/i18n/es.json
@@ -388,5 +388,8 @@
     "restVersion": "Rest Version",
     "softwareVersion": "Version",
     "remote": "Remote",
-    "main": "Main"
+    "main": "Main",
+    "linkedAddress": "Linked",
+    "nodeAddress": "Node",
+    "vrfAddress": "VRF"
 }

--- a/src/config/i18n/ja.json
+++ b/src/config/i18n/ja.json
@@ -392,5 +392,8 @@
     "restVersion": "Rest Version",
     "softwareVersion": "Version",
     "remote": "Remote",
-    "main": "Main"
+    "main": "Main",
+    "linkedAddress": "Linked",
+    "nodeAddress": "Node",
+    "vrfAddress": "VRF"
 }

--- a/src/config/i18n/ja.json
+++ b/src/config/i18n/ja.json
@@ -390,5 +390,7 @@
     "timestamp": "Timestamp",
     "symbolTime": "Symbol Time",
     "restVersion": "Rest Version",
-    "softwareVersion": "Version"
+    "softwareVersion": "Version",
+    "remote": "Remote",
+    "main": "Main"
 }

--- a/src/config/i18n/pt.json
+++ b/src/config/i18n/pt.json
@@ -389,5 +389,8 @@
     "restVersion": "Rest Version",
     "softwareVersion": "Version",
     "remote": "Remote",
-    "main": "Main"
+    "main": "Main",
+    "linkedAddress": "Linked",
+    "nodeAddress": "Node",
+    "vrfAddress": "VRF"
 }

--- a/src/config/i18n/pt.json
+++ b/src/config/i18n/pt.json
@@ -387,5 +387,7 @@
     "timestamp": "Timestamp",
     "symbolTime": "Symbol Time",
     "restVersion": "Rest Version",
-    "softwareVersion": "Version"
+    "softwareVersion": "Version",
+    "remote": "Remote",
+    "main": "Main"
 }

--- a/src/config/i18n/ru.json
+++ b/src/config/i18n/ru.json
@@ -386,5 +386,7 @@
     "timestamp": "Timestamp",
     "symbolTime": "Symbol Time",
     "restVersion": "Rest Version",
-    "softwareVersion": "Version"
+    "softwareVersion": "Version",
+    "remote": "Remote",
+    "main": "Main"
 }

--- a/src/config/i18n/ru.json
+++ b/src/config/i18n/ru.json
@@ -388,5 +388,8 @@
     "restVersion": "Rest Version",
     "softwareVersion": "Version",
     "remote": "Remote",
-    "main": "Main"
+    "main": "Main",
+    "linkedAddress": "Linked",
+    "nodeAddress": "Node",
+    "vrfAddress": "VRF"
 }

--- a/src/config/i18n/ua.json
+++ b/src/config/i18n/ua.json
@@ -386,5 +386,7 @@
     "timestamp": "Timestamp",
     "symbolTime": "Symbol Time",
     "restVersion": "Rest Version",
-    "softwareVersion": "Version"
+    "softwareVersion": "Version",
+    "remote": "Remote",
+    "main": "Main"
 }

--- a/src/config/i18n/ua.json
+++ b/src/config/i18n/ua.json
@@ -388,5 +388,8 @@
     "restVersion": "Rest Version",
     "softwareVersion": "Version",
     "remote": "Remote",
-    "main": "Main"
+    "main": "Main",
+    "linkedAddress": "Linked",
+    "nodeAddress": "Node",
+    "vrfAddress": "VRF"
 }

--- a/src/config/i18n/zh.json
+++ b/src/config/i18n/zh.json
@@ -386,5 +386,7 @@
     "timestamp": "Timestamp",
     "symbolTime": "Symbol Time",
     "restVersion": "Rest Version",
-    "softwareVersion": "Version"
+    "softwareVersion": "Version",
+    "remote": "Remote",
+    "main": "Main"
 }

--- a/src/config/i18n/zh.json
+++ b/src/config/i18n/zh.json
@@ -388,5 +388,8 @@
     "restVersion": "Rest Version",
     "softwareVersion": "Version",
     "remote": "Remote",
-    "main": "Main"
+    "main": "Main",
+    "linkedAddress": "Linked",
+    "nodeAddress": "Node",
+    "vrfAddress": "VRF"
 }

--- a/src/config/key-redirects.json
+++ b/src/config/key-redirects.json
@@ -19,6 +19,10 @@
     "addressAdditions_": "accounts",
     "addressDeletions_": "accounts",
     "linkedAccountAddress": "accounts",
+    "linkedAddress": "accounts",
+    "nodeAddress": "accounts",
+    "vrfAddress": "accounts",
+    "voting_": "accounts",
 
     "transaction": "transactions",
     "transactionHash": "transactions",

--- a/src/config/pages/account-detail.json
+++ b/src/config/pages/account-detail.json
@@ -121,9 +121,9 @@
 				"hideOnError": true,
 				"hideDependOnGetter": "account/info",
 				"fields": [
-					"linked",
-					"node",
-					"vrf",
+					"linkedAddress",
+					"nodeAddress",
+					"vrfAddress",
 					"voting"
 				]
 			},

--- a/src/infrastructure/AccountService.js
+++ b/src/infrastructure/AccountService.js
@@ -41,7 +41,7 @@ class AccountService {
 
 	/**
 	 * Gets an AccountInfo for an account.
-	 * @param address
+	 * @param addresses Array
 	 * @returns Formatted AccountInfo
 	 */
 	static getAccounts = async addresses => {
@@ -107,7 +107,7 @@ class AccountService {
 	 * @returns Custom AccountInfo
 	 */
 	static getAccountInfo = async address => {
-		const accountInfo = await this.getAccount(address);
+		const { supplementalPublicKeys, ...accountInfo } = await this.getAccount(address);
 		const accountNames = await NamespaceService.getAccountsNames([Address.createFromRawAddress(address)]);
 
 		return {
@@ -119,8 +119,11 @@ class AccountService {
 				importanceScore: activity.rawScore
 			})),
 			supplementalPublicKeys: {
-				...accountInfo.supplementalPublicKeys,
-				voting: Array.isArray(accountInfo.supplementalPublicKeys.voting) ? accountInfo.supplementalPublicKeys.voting.map(voting => voting.publicKey) : accountInfo.supplementalPublicKeys.voting
+				...supplementalPublicKeys,
+				linkedAddress: supplementalPublicKeys.linked === Constants.Message.UNAVAILABLE ? supplementalPublicKeys.linked : helper.publicKeyToAddress(supplementalPublicKeys.linked),
+				nodeAddress: supplementalPublicKeys.node === Constants.Message.UNAVAILABLE ? supplementalPublicKeys.node : helper.publicKeyToAddress(supplementalPublicKeys.node),
+				vrfAddress: supplementalPublicKeys.vrf === Constants.Message.UNAVAILABLE ? supplementalPublicKeys.vrf : helper.publicKeyToAddress(supplementalPublicKeys.vrf),
+				voting: supplementalPublicKeys.voting.length > 0 ? supplementalPublicKeys.voting.map(voting => helper.publicKeyToAddress(voting.publicKey)) : []
 			},
 			accountAliasNames: this.extractAccountNamespace(accountInfo, accountNames)
 		};

--- a/src/store/block.js
+++ b/src/store/block.js
@@ -22,7 +22,8 @@ import { filters, Constants } from '../config';
 import helper from '../helper';
 import {
 	ListenerService,
-	BlockService
+	BlockService,
+	AccountService
 } from '../infrastructure';
 import {
 	DataSet,
@@ -131,10 +132,15 @@ export default {
 					async (item) => {
 						const latestBlock = await BlockService.getBlockByHeight(item.height.compact());
 
+						const { supplementalPublicKeys } = await AccountService.getAccount(latestBlock.signer);
+
 						getters.timeline.addLatestItem({
 							...latestBlock,
 							age: helper.convertToUTCDate(latestBlock.timestamp),
-							harvester: latestBlock.signer
+							harvester: {
+								signer: latestBlock.signer,
+								linkedAddress: supplementalPublicKeys.linked === Constants.Message.UNAVAILABLE ? latestBlock.signer : helper.publicKeyToAddress(supplementalPublicKeys.linked)
+							}
 						}, 'height');
 
 						dispatch('chain/getChainInfo', null, { root: true });


### PR DESCRIPTION
# Added
-  `harvester` field displays the Remote address, and redirect to the Main address In the Blocks list and blocks detail Page.
- disable on row click on TableInfoView.
- Enable supplemental Keys clickable on the account detail page.

![image](https://user-images.githubusercontent.com/5649156/114422788-2aa3df80-9be9-11eb-9d93-04d17f01b517.png)

![image](https://user-images.githubusercontent.com/5649156/114422926-48714480-9be9-11eb-8b98-8ca83101387a.png)
