### PR TITLE
Bug fix

### DIFF
--- a/src/components/TimeSince.vue
+++ b/src/components/TimeSince.vue
@@ -53,11 +53,11 @@ export default {
 	},
 	methods: {
 		updateDateAge() {
-			let now = moment(moment.utc(Date.now()).format(), 'YYYY-MM-DD HH:mm:ss').utc();
+			const now = moment(moment.utc(Date.now()).format(), 'YYYY-MM-DD HH:mm:ss').utc();
 
-			let date = moment(this.date, 'YYYY-MM-DD HH:mm:ss').utc();
+			const date = moment(this.date, 'YYYY-MM-DD HH:mm:ss').utc();
 
-			let diff = now.diff(date);
+			let diff = Math.max(0, now.diff(date)) || 0;
 
 			this.years = Math.floor(diff / this.intervals.year);
 			diff -= this.years * this.intervals.year;

--- a/src/components/controls/ExportCSVButton.vue
+++ b/src/components/controls/ExportCSVButton.vue
@@ -35,7 +35,7 @@ export default {
 			link.click();
 		},
 
-        getNameByKey(e) {
+		getNameByKey(e) {
 			return this.$store.getters['ui/getNameByKey'](e);
 		}
 	}

--- a/src/infrastructure/StatisticService.js
+++ b/src/infrastructure/StatisticService.js
@@ -120,7 +120,7 @@ class StatisticService {
 
 		for (let i = 0; i < numTransactions.length - 1; ++i) {
 			numTransactionsPerBlockDataset.push([heights[i], numTransactions[i]]);
-			averagesDataset.push([heights[i], Math.floor(averages[i])]);
+			averagesDataset.push([heights[i], averages[i] === undefined ? 0 : averages[i].toFixed(2)]);
 		}
 
 		const sliceNumTransactionsPerBlockDataset = numTransactionsPerBlockDataset.slice(0, numTransactionsPerBlockDataset.length - grouping);


### PR DESCRIPTION
# Bug fixes
- prevent time compared in negative value and cause the problem #873
- removed `math.floor` in TransactionPerBlock statistics chart data.

![image](https://user-images.githubusercontent.com/5649156/115425702-6ca8d300-a232-11eb-9259-431269bdbaad.png)
 
 no sure why I can't add you as Reviewers, so I just tag here @segfaultxavi  ;) 